### PR TITLE
Support casting to atom from strings

### DIFF
--- a/lib/ecto_atom.ex
+++ b/lib/ecto_atom.ex
@@ -17,7 +17,8 @@ defmodule Ecto.Atom do
   def type, do: :string
 
   def cast(value) when is_atom(value), do: {:ok, value}
-  def cast(_), do: :error
+  def cast(value) when is_binary(value), do: {:ok, String.to_existing_atom(value)}
+  def cast(_), do: :error  
 
   def load(value), do: {:ok, String.to_existing_atom(value)}
 

--- a/lib/ecto_atom.ex
+++ b/lib/ecto_atom.ex
@@ -17,7 +17,11 @@ defmodule Ecto.Atom do
   def type, do: :string
 
   def cast(value) when is_atom(value), do: {:ok, value}
-  def cast(value) when is_binary(value), do: {:ok, String.to_existing_atom(value)}
+  def cast(value) when is_binary(value) do
+    {:ok, String.to_existing_atom(value)}
+  rescue
+    ArgumentError -> {:error, [message: "atom not found"]}
+  end
   def cast(_), do: :error  
 
   def load(value), do: {:ok, String.to_existing_atom(value)}


### PR DESCRIPTION
Ecto types can be so hard for me to wrap my head around sometimes, but I'm pretty sure this is right 😅 

Here's an example from the docs with comments that I think are really helpful (I think they might be relatively new):
https://hexdocs.pm/ecto/Ecto.Type.html#module-example

But basically, `dump` takes what's on the Ecto schema struct and turns it into the database format.  So `cast` is to take potentially supported values (e.g. in forms) and turn them into the data type that's expected to be on the Ecto schema struct.  Basically `load` while is loading from the DB, `cast` is kind of like "loading" from the outside world, and thus potentially needs to support different types of data.

In that example in the docs, there should always be a `%URI{}` on the schema struct.  So `cast` takes strings and `%URI{}` values and assigns them (I could imagine it also taking maps with the URL parts, depending on what you wanted to do).